### PR TITLE
refactor redis error

### DIFF
--- a/src/database/cache.rs
+++ b/src/database/cache.rs
@@ -1,41 +1,38 @@
 use super::{error::DatabaseError, redis::RedisWrapper};
 use r2d2_redis::redis::RedisError;
 use serde_cbor::Error as SerdeCborError;
-use std::convert;
+use std::{convert, sync::Arc};
 
 pub struct CacheWrapper {
     redis: RedisWrapper,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CacheError {
-    DatabaseError(DatabaseError),
-    RedisError(RedisError),
-    SerdeCborError(SerdeCborError),
-}
-
-impl convert::From<DatabaseError> for CacheError {
-    fn from(err: DatabaseError) -> Self {
-        CacheError::DatabaseError(err)
-    }
+    RedisError(Arc<RedisError>),
+    SerdeCborError(Arc<SerdeCborError>),
 }
 
 impl convert::From<RedisError> for CacheError {
     fn from(err: RedisError) -> Self {
-        CacheError::RedisError(err)
+        CacheError::RedisError(Arc::new(err))
     }
 }
 
 impl convert::From<SerdeCborError> for CacheError {
     fn from(err: SerdeCborError) -> Self {
-        CacheError::SerdeCborError(err)
+        CacheError::SerdeCborError(Arc::new(err))
     }
 }
 
 pub trait CacheModule {
-    fn set<K: Into<String>>(&self, key: K, value: Vec<u8>, expire: usize)
-        -> Result<(), CacheError>;
-    fn get<K: Into<String>>(&self, key: K) -> Result<Vec<u8>, CacheError>;
+    fn set<K: Into<String>>(
+        &self,
+        key: K,
+        value: Vec<u8>,
+        expire: usize,
+    ) -> Result<(), DatabaseError>;
+    fn get<K: Into<String>>(&self, key: K) -> Result<Vec<u8>, DatabaseError>;
 }
 
 impl CacheWrapper {
@@ -43,21 +40,34 @@ impl CacheWrapper {
         Self { redis }
     }
 
-    pub fn set<K, V>(&self, key: K, value: &V, expire: usize) -> Result<(), CacheError>
+    pub fn set<K, V>(&self, key: K, value: &V, expire: usize) -> Result<(), DatabaseError>
     where
         K: std::convert::Into<String>,
         V: serde::ser::Serialize,
     {
-        let cbor = serde_cbor::to_vec(&value)?;
-        self.redis.set(key, cbor, expire)
+        let cbor = match serde_cbor::to_vec(&value) {
+            Err(err) => {
+                return Err(DatabaseError::CacheError(CacheError::SerdeCborError(
+                    Arc::new(err),
+                )))
+            }
+            Ok(cbor) => cbor,
+        };
+        self.redis.set(key, cbor, expire)?;
+        Ok(())
     }
 
-    pub fn get<K, V>(&self, key: K) -> Result<V, CacheError>
+    pub fn get<K, V>(&self, key: K) -> Result<V, DatabaseError>
     where
         K: std::convert::Into<String>,
         V: for<'a> serde::de::Deserialize<'a>,
     {
         let cbor: Vec<u8> = self.redis.get(key)?;
-        Ok(serde_cbor::de::from_slice::<V>(&cbor[..])?)
+        match serde_cbor::de::from_slice::<V>(&cbor[..]) {
+            Err(err) => Err(DatabaseError::CacheError(CacheError::SerdeCborError(
+                Arc::new(err),
+            ))),
+            Ok(cbor) => Ok(cbor),
+        }
     }
 }

--- a/src/database/cache.rs
+++ b/src/database/cache.rs
@@ -40,6 +40,7 @@ impl CacheWrapper {
         Self { redis }
     }
 
+    #[allow(dead_code)]
     pub fn set<K, V>(&self, key: K, value: &V, expire: usize) -> Result<(), DatabaseError>
     where
         K: std::convert::Into<String>,
@@ -57,6 +58,7 @@ impl CacheWrapper {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn get<K, V>(&self, key: K) -> Result<V, DatabaseError>
     where
         K: std::convert::Into<String>,

--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -1,3 +1,4 @@
+use super::cache::CacheError;
 use mysql::Error as MysqlError;
 use scylla::{
     cql_to_rust::FromRowError as ScyllaFromRowError,
@@ -12,6 +13,7 @@ pub enum DatabaseError {
     ScyllaFromRowError(ScyllaFromRowError),
     MysqlError(Arc<MysqlError>),
     R2d2Error(String),
+    CacheError(CacheError),
     Other(String),
 }
 
@@ -42,5 +44,11 @@ impl convert::From<MysqlError> for DatabaseError {
 impl convert::From<r2d2::Error> for DatabaseError {
     fn from(err: r2d2::Error) -> Self {
         DatabaseError::R2d2Error(err.to_string())
+    }
+}
+
+impl convert::From<CacheError> for DatabaseError {
+    fn from(err: CacheError) -> Self {
+        DatabaseError::CacheError(err)
     }
 }


### PR DESCRIPTION
- Make `CacheError` a kind of `DatabaseError` for better error handling reason.
- Add `#[allow(dead_code)]` to the cache setter and getter so the compiler stop throw unused warnings on it.